### PR TITLE
Fixed a variable typo

### DIFF
--- a/learndapper.com/pages/non-query.md
+++ b/learndapper.com/pages/non-query.md
@@ -24,7 +24,7 @@ object[] parameters = { new { Name = "John Doe", Email = "jdoe@example.com" } };
 	
 using (var connection = new SqlConnection(connectionString))
 {
-    conn.Execute(sql, parameters); 
+    connection.Execute(sql, parameters); 
 }
 ```
 


### PR DESCRIPTION
Variable was declared as connection, however the Execute method was called on conn, which doesn't exist. It could confuse people like it confused me, thinking conn was a static class with an execute method.