### PR TITLE
Fix Value type to be struc as text implies

### DIFF
--- a/learnentityframeworkcore.com/pages/model/complex-type.md
+++ b/learnentityframeworkcore.com/pages/model/complex-type.md
@@ -87,7 +87,7 @@ protected override void OnModelCreating(ModelBuilder modelBuilder)
 Unlike reference types, value types are immutable and represent data objects. So to create a `Complex Type` as a Value Type, we simply create a `struct` instead of a `class`:
 
 ```csharp
-public class Address
+public struct Address
 {
     public string Street { get; set; }
     public string City { get; set; }


### PR DESCRIPTION
Changes Address in Value type example to be struct as implied by text.

Open Question:
- Is OnModelCreation `x.ComplexProperty()` needed in this case? Since `[ComplexType]` om struct here gives `Attribute 'ComplexType' is not valid on this declaration type. It is only valid on 'class' declarations.CS0592`