### PR TITLE
Fix Oracle parameter syntax from '@' to ':'

### DIFF
--- a/learndapper.com/pages/database-providers.md
+++ b/learndapper.com/pages/database-providers.md
@@ -58,7 +58,7 @@ var connectionString = "Data Source=(DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCO
 using (var connection = new OracleConnection(connectionString)) 
 {    
     // Create a query that retrieves all books with an author name of "John Smith"    
-    var sql = "SELECT * FROM Books WHERE Author=@authorName";     
+    var sql = "SELECT * FROM Books WHERE Author=:authorName";     
 
     // Use the Query method to execute the query and return a list of objects    
     var books = connection.Query<Book>(sql, new {authorName="John Smith"}).ToList(); 


### PR DESCRIPTION
Oracle.ManagedDataAccess.Client requires colon-prefixed parameters (e.g., :paramName) instead of at-signs (@paramName). 

The original example results in a runtime error: https://docs.oracle.com/en/error-help/db/ora-00936